### PR TITLE
Adds a context to all JSON postmessage data

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -2,6 +2,7 @@ var playerjs = {};
 
 playerjs.DEBUG = false;
 playerjs.POST_MESSAGE = !!window.postMessage;
+playerjs.POST_MESSAGE_CONTEXT = 'player.js';
 
 /*
 * Utils.

--- a/src/player.js
+++ b/src/player.js
@@ -107,6 +107,8 @@ playerjs.Player.prototype.init = function(elem, options){
 };
 
 playerjs.Player.prototype.send = function(data, callback, ctx){
+  data.context = playerjs.POST_MESSAGE_CONTEXT;
+
   // We are expecting a response.
   if (callback) {
     // Create a UUID
@@ -146,6 +148,11 @@ playerjs.Player.prototype.receive = function(e){
     data = JSON.parse(e.data);
   } catch (err){
     // Not a valid response.
+    return false;
+  }
+
+  // abort if this message wasn't a player.js message
+  if (data.context !== playerjs.POST_MESSAGE_CONTEXT) {
     return false;
   }
 
@@ -302,7 +309,8 @@ playerjs.addEvent(window, 'message', function(e){
   }
 
   // We need to determine if we are ready.
-  if (data.event === 'ready' && data.value.src){
+  if (data.context === playerjs.POST_MESSAGE_CONTEXT && data.event === 'ready' &&
+      data.value && data.value.src){
     playerjs.READIED.push(data.value.src);
   }
 });

--- a/src/receiver.js
+++ b/src/receiver.js
@@ -65,7 +65,7 @@ playerjs.Receiver.prototype.receive = function(e){
   playerjs.log('Receiver.receive', e, data);
 
   // Nothing for us to do.
-  if (!data.method){
+  if (data.context !== playerjs.POST_MESSAGE_CONTEXT || !data.method){
     return false;
   }
 
@@ -155,6 +155,7 @@ playerjs.Receiver.prototype.send = function(event, value, listener){
     return false;
   }
   var data = {
+    context: playerjs.POST_MESSAGE_CONTEXT,
     event: event
   };
 


### PR DESCRIPTION
Without some sort of name spacing it is very easy for there to be a conflict between various postMessage messages flying around. We experienced a problem with a Vimeo `ready` message being read by `player.js` and throwing an exception. Specifically in

``` javascript
  if (data.event === 'ready' && data.value.src === this.elem.src){
    this.ready(data);
  }
```

Vimeo was firing a `ready` event, but there was no `data.value` and so an exception was thrown.

I am sort of hoping all frameworks using postMessage start name spacing in this way to avoid stepping on each other.

I am unclear on whether player.js implementors are dealing with postMessage messages directly, or always using this library. If receivers are dealing with the messages directly this change shouldn't affect them since the only new piece of data is "context". For message publishers, if they are publishing without this context, but the reciever is expecting context, there will be a migration issue.
