### PR TITLE
Added bower support to readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -30,6 +30,12 @@ Player.js is hosted on Embedly's CDN.
 ::
 
   <script type="text/javascript" src="//cdn.embed.ly/player-0.0.10.min.js"></script>
+  
+Alternatively, you can also install Player.js via bower (experimental):
+
+::
+
+  bower install git@github.com:embedly/player.js.git#master -S
 
 
 Ready


### PR DESCRIPTION
Since people (like me) will notice that there is a bower.json file in the repository, they might try to install the file via bower and wonder why it does not work. So I thought it might be better to inform them.