### PR TITLE
Fix JWPlayer adapter getPaused function

### DIFF
--- a/src/adapters/jwplayer.js
+++ b/src/adapters/jwplayer.js
@@ -69,7 +69,7 @@ playerjs.JWPlayerAdapter.prototype.init = function(player){
   });
 
   receiver.on('getPaused', function(callback){
-    callback(player.getState() !== 'PLAYING');
+    callback(player.getState().toLowerCase() !== 'PLAYING'.toLowerCase());
   });
 
   receiver.on('getCurrentTime', function(callback){


### PR DESCRIPTION
Hi, I have a newer version of JWPlayer that returns "playing" not "PLAYING" from getPaused() function. This fix should make either uppercase or lowercase version work.