### PR TITLE
Readme: remove unexisting 'seeked' event

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,9 +243,6 @@ fires when the video is paused.
 `ended`
 fires when the video is finished.
 
-`seeked`
-fires when the video has been seeked by the user.
-
 `error`
 fires when an error occurs.
 


### PR DESCRIPTION
- The README.md states that there's a 'seeked' event but it seems that it doesn't exist (anymore?)